### PR TITLE
Implemented "anchor_wait_duration"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio-timerfd = "0.2"
 uuid = { version = "1", features = ["v7"] }
 
 [workspace.package]
-version = "0.8.2"
+version = "0.9.2"
 edition = "2021"
 authors = ["Ivan Kudriavtsev <ivan.a.kudryavtsev@gmail.com>"]
 description = "ReplayDB Service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio-timerfd = "0.2"
 uuid = { version = "1", features = ["v7"] }
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.0"
 edition = "2021"
 authors = ["Ivan Kudriavtsev <ivan.a.kudryavtsev@gmail.com>"]
 description = "ReplayDB Service"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78 as builder
+FROM rust:1.78 AS builder
 
 WORKDIR /opt/replay
 COPY . .
@@ -8,6 +8,12 @@ RUN build/docker-deps.sh
 RUN cargo build --release
 RUN build/copy-deps.sh
 RUN cargo clean
+
+FROM debian:bookworm-slim AS runner
+
+COPY --from=builder /opt /opt
+
+WORKDIR /opt/replay
 
 ENV LD_LIBRARY_PATH=/opt/libs
 ENV DB_PATH=/opt/rocksdb

--- a/docs/sections/3_jobs.rst
+++ b/docs/sections/3_jobs.rst
@@ -32,6 +32,8 @@ Replay uses frame UUIDs to navigate the video stream. UUIDs are used to find key
 
     MJPEG and image streams have every frame marked as a keyframe. Thus streams create significantly more indexing information in Replay and thus can require more resources to process.
 
+In certain situations users may encounter cases when frames are not yet delivered to Replay at the moment of the job creation. In this case, the job may wait for the frame to be delivered and then start processing the stream. There is a special optional parameter in the job specification for this case.
+
 Job Offset
 ----------
 

--- a/docs/sections/4_api.rst
+++ b/docs/sections/4_api.rst
@@ -180,6 +180,10 @@ Creates a new job. Returns the job UUID.
         "frame_count": 10000
       },
       "anchor_keyframe": "$ANCHOR_KEYFRAME",
+      "anchor_wait_duration": {
+        "secs": 1,
+        "nanos": 0
+      },
       "offset": {
         "blocks": 5
       },
@@ -532,6 +536,10 @@ All Configuration Parameters
       - anchor keyframe UUID
       - ``"018f76e3-a0b9-7f67-8f76-ab0402fda78e"``
       - ``"018f76e3-a0b9-7f67-8f76-ab0402fda78e"``
+    * - ``anchor_wait_duration``
+      - defines how long the job waits for late anchor keyframes that are not yet arrived to the system
+      - ``null``
+      - ``{"secs": 1, "nanos": 0}``
     * - ``offset``
       - job offset; see the `Offset`_ section for more details
       - ``{...}``

--- a/replay/scripts/rest_api/new_job.sh
+++ b/replay/scripts/rest_api/new_job.sh
@@ -57,6 +57,10 @@ cat <<EOF
   },
   "stop_condition": "never",
   "anchor_keyframe": "$ANCHOR_KEYFRAME",
+  "anchor_wait_duration": {
+    "secs": 1,
+    "nanos": 0
+  },
   "offset": {
     "blocks": 5
   },

--- a/replaydb/src/job/query.rs
+++ b/replaydb/src/job/query.rs
@@ -5,6 +5,7 @@ use crate::store::JobOffset;
 use anyhow::Result;
 use savant_core::primitives::Attribute;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -13,26 +14,30 @@ pub struct JobQuery {
     pub configuration: JobConfiguration,
     pub stop_condition: JobStopCondition,
     pub anchor_keyframe: String,
+    pub anchor_wait_duration: Option<Duration>,
     pub offset: JobOffset,
     pub attributes: Vec<Attribute>,
 }
 
 impl JobQuery {
     pub fn new(
-        socket: SinkConfiguration,
+        sink: SinkConfiguration,
         configuration: JobConfiguration,
         stop_condition: JobStopCondition,
         anchor_keyframe: Uuid,
+        anchor_wait_duration: Option<Duration>,
         offset: JobOffset,
         attributes: Vec<Attribute>,
     ) -> Self {
+        let anchor_keyframe = anchor_keyframe.to_string();
         Self {
-            sink: socket,
+            sink,
             configuration,
             stop_condition,
             offset,
             attributes,
-            anchor_keyframe: anchor_keyframe.to_string(),
+            anchor_keyframe,
+            anchor_wait_duration,
         }
     }
 
@@ -82,6 +87,7 @@ mod tests {
             configuration,
             stop_condition,
             incremental_uuid_v7(),
+            Some(Duration::from_secs(1)),
             offset,
             vec![Attribute::persistent(
                 "key",


### PR DESCRIPTION
The allows sending jobs before the frames are actually delivered to a Replay database.